### PR TITLE
Deal with 'o', double 'u'

### DIFF
--- a/ipa-uk.py
+++ b/ipa-uk.py
@@ -134,6 +134,8 @@ def ipa(text: str, check_accent: bool) -> str:
         r"([йклмнпрстфхцчшщ])\1": r"\1ː",
         r"дждж": r"джː",
         r"дздз": r"дзː",
+        # double vowels:
+        r"уу": r"уː",
     }
 
     phonetic: str = text
@@ -153,7 +155,7 @@ def ipa(text: str, check_accent: bool) -> str:
     # including stress mark for single-syllable words if check_accent is set to true
     number_of_vowels = len(re.findall(r"[ɑɛiɪuɔ]", phonetic))
     if number_of_vowels == 1 and check_accent:
-        phonetic = re.sub(r"([ɑɛiɪuɔ])", r"ˈ\1", phonetic)
+        phonetic = re.sub(r"([ɑɛiɪuo])", r"ˈ\1", phonetic)
 
     # palatalizable consonants before /i/ or /j/ become palatalized
     phonetic = re.sub(r"(" + palatalizable + ")([ː]?)([ˈ]?)i", r"\1ʲ\2\3i", phonetic)
@@ -222,11 +224,12 @@ def ipa(text: str, check_accent: bool) -> str:
     # unstressed /ɑ/ has an allophone [ɐ]
     phonetic = re.sub(r"([^ˈ])ɑ", r"\1ɐ", phonetic)
     phonetic = re.sub(r"^ɑ", r"ɐ", phonetic)
-    # unstressed /u/ has an allophone [ʊ]
-    phonetic = re.sub(r"([^ˈ])u", r"\1ʊ", phonetic)
-    phonetic = re.sub(r"^u", r"ʊ", phonetic)
+    # unstressed /ɔ/ has a stressed allophone [o]
+    phonetic = re.sub(r"(ˈ)ɔ", r"\1o", phonetic)
     # unstressed /ɔ/ has by assimilation an allophone [o] before a stressed syllable with /u/ or /i/
     phonetic = re.sub(r"ɔ([bdzʒɡɦmnlrpftskxʲʃ͡]+)ˈ([uiʊ]+)", r"o\1ˈ\2", phonetic)
+    # unstressed /u/ has an allophone [ʊ]
+    phonetic = re.sub(r"([^ˈ])u", r"\1ʊ", phonetic)
     # one allophone [e] covers unstressed /ɛ/ and /ɪ/
     phonetic = re.sub(r"([^ˈ])ɛ", r"\1e", phonetic)
     phonetic = re.sub(r"^ɛ", r"e", phonetic)
@@ -261,5 +264,9 @@ def ipa(text: str, check_accent: bool) -> str:
 
 
 if __name__ == "__main__":
-    for w in [f"Сла{ACUTE}ва", f"Украї{ACUTE}ні", f"сме{ACUTE}рть", f"ворога{ACUTE}м"]:
+    for w in [f"Сла{ACUTE}ва", f"Украї{ACUTE}ні", f"сме{ACUTE}рть", f"ворога{ACUTE}м",
+              # подвійний "у"
+              f"ва{ACUTE}куум",
+              # "o"
+              f"при{ACUTE}пхнутого", f"поверхово{ACUTE}див", f"електро{ACUTE}нні"]:
         print(w, "->", ipa(w, check_accent=True))


### PR DESCRIPTION
Дублюю пояснення тут:

щодо голосних мій головний concern зараз в тому, що наголошені і ненаголошені “o” позначаються однаково - знаком [ɔ]:

при́пхнутого -> ˈprɪpxnʊtɔɦɔ
поверхово́див -> pɔu̯erxɔˈu̯ɔdeu̯
електро́нні -> eleˈktrɔnʲːi
а́еродром -> ˈɑerɔdrɔm

а в вікіпедії взагалі написано що ɔ це знак наголошеного “о”, що типу взагалі протилежне тому що в коді пишуть в коментарях, тому я думаю що в вікі помилка просто на цій сторінці https://uk.wikipedia.org/wiki/%D0%94%D0%BE%D0%B2%D1%96%D0%B4%D0%BA%D0%B0:%D0%9C%D0%A4%D0%90/%D0%A3%D0%BA%D1%80%D0%B0%D1%97%D0%BD%D1%81%D1%8C%D0%BA%D0%B0

тому що якщо зайти на сторінку звука ɔ, то там написано “Один з основних звуків української мови. Має наголошений алофон — звук [o̞] (поїзд)” https://uk.wikipedia.org/wiki/%D0%9E%D0%B3%D1%83%D0%B1%D0%BB%D0%B5%D0%BD%D0%B8%D0%B9_%D0%B3%D0%BE%D0%BB%D0%BE%D1%81%D0%BD%D0%B8%D0%B9_%D0%B7%D0%B0%D0%B4%D0%BD%D1%8C%D0%BE%D0%B3%D0%BE_%D1%80%D1%8F%D0%B4%D1%83_%D0%BD%D0%B8%D0%B7%D1%8C%D0%BA%D0%BE%D1%81%D0%B5%D1%80%D0%B5%D0%B4%D0%BD%D1%8C%D0%BE%D0%B3%D0%BE_%D0%BF%D1%96%D0%B4%D0%BD%D1%8F%D1%82%D1%82%D1%8F
тобто цей самий звук - це позначка ненаголошеного “o”

також вирішила виправити те як транскрибується 'вакуум' :)